### PR TITLE
GitHub Action workflow to create new releases on Tag push

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,23 @@
+name: Create Bicep template release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Bicep template release package
+      run: zip -r ${{ github.event.repository.name }}-${{ github.ref_name }}.zip . -x ".git/*" ".github/*" ".gitignore"
+
+    - name: Create Bicep template release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: ${{ github.event.repository.name }}-${{ github.ref_name }}.zip
+        make_latest: true


### PR DESCRIPTION
Created GitHub Action workflow to create a new release if a new tag is pushed to the repository.